### PR TITLE
Added Pckd to the list of hosted URL Shorteners

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Url Shortener Services
 
 * [T.LY](https://t.ly)
+* [Pckd.me](https://pckd.me/about)
 * [bit.ly](https://bitly.com)
 * [is.gd](https://is.gd)
 * [Ow.ly](https://ow.ly)


### PR DESCRIPTION
Since Pckd is provided as a hosted service, it makes sense to add it to the list