### PR TITLE
Add gg.gg URL shortner

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 * [short.io](https://short.io)
 * [kutt.it](https://kutt.it)
 * [switchy.io](https://switchy.io)
+* [gg.gg](http://gg.gg)
 * [urlr.me](https://urlr.me/en) - Reliable URL shortener that provide an API
 * [name.com](https://www.name.com/branded-url-shortener) - Powered by bli.nk
 * [han.gl](https://han.gl) - Korean URL Shortener Service


### PR DESCRIPTION
[gg.gg](http://gg.gg) doesn't yet support HTTPS (only can request via HTTP), have some features like custom URL.