### PR TITLE
Add pygmy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 * [yourls](https://yourls.org)
 * [shlink](https://shlink.io)
 * [Pckd](https://github.com/Just-Moh-it/Pckd) - free, flexible, open source, simple to install, good tracking, customizable
+* [pygmy](https://github.com/amitt001/pygmy) - An open-source, feature rich & extensible url-shortener + analytics written in Python.
 
 ## Deprecated Services
 


### PR DESCRIPTION
Add [pygmy](https://github.com/amitt001/pygmy) - an open-source url-shortener with analytics written in Python.