### PR TITLE
[hoy.kr](https://hoy.kr/) - Deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 * [fox.ly](https://foxlyme.com/) - Optimize your URL
 * [gg.gg](https://gg.gg)
 * [han.gl](https://han.gl) - Korean URL Shortener Service
-* [hoy.kr](https://hoy.kr/) - Korean URL Shortener Service
 * [is.gd](https://is.gd)
 * [KurzeLinks.de](https://kurzelinks.de) - Link shortener based in Germany.
 * [kutt.it](https://kutt.it)
@@ -68,6 +67,7 @@
 * [me2.do](https://me2.do) - deprecated from Naver (2016-08-18)
 * [s2r.co](https://s2r.co)
 * [soo.gd](https://soo.gd/)
+* [hoy.kr](https://hoy.kr/)
 
 ## Contributing
 


### PR DESCRIPTION
It seems that https://hoy.kr/ is down.