### PR TITLE
Add URL-shortener 73.nu to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 * [sor.bz](https://sor.bz) - free customizable url shortener.
 * [3.ly](https://3.ly)
+* [73.nu](https://shorturl.73.nu) - Also offers LinkHub and Pastebin
 * [bit.ly](https://bitly.com)
 * [bitly.kr](https://bitly.kr) - Korean URL Shortener Service
 * [bl.ink](https://www.bl.ink)


### PR DESCRIPTION
shorturl.73.nu offers free link shortening on a very short domain with premium functionality. The Website also offers tools like a Pastebin and LinkHub