### PR TITLE
Add Linkly to URL shortener services list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## Url Shortener Services
 
+* [Linkly](https://linklyhq.com) - URL shortener with georedirects, QR codes, app redirects, domains and live data feeds for Google Sheets.
 * [SimpleURL](https://simpleURL.tech) - Free custom/private URL Shortner that also allows to Search Bookmarked URLs & Short URLs.
 * [sor.bz](https://sor.bz) - free customizable url shortener.
 * [73.nu](https://shorturl.73.nu) - Also offers LinkHub and Pastebin


### PR DESCRIPTION
Added [Linkly](https://linklyhq.com) to the list of URL shortener services.