### PR TITLE
Add QR-Guru (GDPR-compliant, Germany-hosted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 * [name.com](https://www.name.com/branded-url-shortener) - Powered by bli.nk
 * [oe.cd](https://oe.cd/) - Only OECD-related URLs can be shortened on this website
 * [Ow.ly](https://ow.ly)
-* * [QR-Guru](https://qr-guru.de) - GDPR-compliant URL shortener with servers exclusively in Germany. Article 28 Data Processing Agreement available on every plan (including the free tier), salted SHA-256 IP hashing with daily salt rotation, no tracking cookies, no US data transfer. Includes a built-in QR code generator with print-quality output (CMYK PDF, SVG).
+* [QR-Guru](https://qr-guru.de) - GDPR-compliant URL shortener with servers exclusively in Germany. Article 28 Data Processing Agreement available on every plan (including the free tier), salted SHA-256 IP hashing with daily salt rotation, no tracking cookies, no US data transfer. Includes a built-in QR code generator with print-quality output (CMYK PDF, SVG).
 * [rebrandly.com](https://rebrandly.com)
 * [reduced.to](https://reduced.to)
 * [rip.to](https://rip.to)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 * [name.com](https://www.name.com/branded-url-shortener) - Powered by bli.nk
 * [oe.cd](https://oe.cd/) - Only OECD-related URLs can be shortened on this website
 * [Ow.ly](https://ow.ly)
+* * [QR-Guru](https://qr-guru.de) - GDPR-compliant URL shortener with servers exclusively in Germany. Article 28 Data Processing Agreement available on every plan (including the free tier), salted SHA-256 IP hashing with daily salt rotation, no tracking cookies, no US data transfer. Includes a built-in QR code generator with print-quality output (CMYK PDF, SVG).
 * [rebrandly.com](https://rebrandly.com)
 * [reduced.to](https://reduced.to)
 * [rip.to](https://rip.to)


### PR DESCRIPTION
Adding QR-Guru as a Germany-based URL shortener built around strict GDPR compliance. Servers are exclusively in Germany (no replicas, no US CDN for hot paths), with an Article 28 GDPR Data Processing Agreement on every plan including the free tier. IP addresses are processed as salted SHA-256 hashes with daily salt rotation (no plaintext, no Schrems-II exposure). No tracking cookies, no browser fingerprinting. Free tier with no time limit (up to 5 active short links). Built-in QR code generator in the same workflow (PNG free, SVG/CMYK paid).

Live at https://qr-guru.de. Happy to adjust wording or position if needed.